### PR TITLE
Xcode 6.2 (6C131e) Support

### DIFF
--- a/KKHighlightRecentPlugin/Info.plist
+++ b/KKHighlightRecentPlugin/Info.plist
@@ -27,6 +27,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
Xcode 6.2 (6C131e) (Mavericks)
